### PR TITLE
Added TxDriverDRes and use it for setting it in the TX driver register

### DIFF
--- a/rnfc-st25r39/src/lib.rs
+++ b/rnfc-st25r39/src/lib.rs
@@ -17,7 +17,7 @@ use embedded_hal::digital::InputPin;
 use embedded_hal_async::digital::Wait;
 pub use interface::{I2cInterface, Interface, SpiInterface};
 
-use self::regs::Regs;
+use self::regs::{Regs, TxDriverDRes};
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_millis(500);
 
@@ -438,7 +438,7 @@ impl<I: Interface, IrqPin: InputPin + Wait> St25r39<I, IrqPin> {
             w.set_en_fd(regs::OpControlEnFd::AUTO_EFD);
         })?;
         self.regs().tx_driver().write(|w| {
-            w.set_d_res(3);
+            w.set_d_res(regs::TxDriverDRes::_1_61);
         })?;
         Ok(())
     }
@@ -704,7 +704,7 @@ impl<'a, I: Interface, IrqPin: InputPin + Wait> Raw<'a, I, IrqPin> {
     pub async fn driver_hi_z(&mut self) -> Result<(), Error<I::Error>> {
         self.inner.mode_off()?;
         self.inner.regs().tx_driver().write(|w| {
-            w.set_d_res(15); // hi-z
+            w.set_d_res(regs::TxDriverDRes::_HIGH_Z); // hi-z
         })?;
 
         Ok(())

--- a/rnfc-st25r39/src/regs.rs
+++ b/rnfc-st25r39/src/regs.rs
@@ -291,12 +291,12 @@ impl<'a, I: Interface> Regs<'a, I> {
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct TxDriver(pub u8);
 impl TxDriver {
-    pub const fn d_res(&self) -> u8 {
+    pub const fn d_res(&self) -> TxDriverDRes {
         let val = (self.0 >> 0usize) & 0x0f;
-        val as u8
+        TxDriverDRes(val as u8)
     }
-    pub fn set_d_res(&mut self, val: u8) {
-        self.0 = (self.0 & !(0x0f << 0usize)) | (((val as u8) & 0x0f) << 0usize);
+    pub fn set_d_res(&mut self, val: TxDriverDRes) {
+        self.0 = (self.0 & !(0x0f << 0usize)) | (((val.0 as u8) & 0x0f) << 0usize);
     }
     pub const fn am_mod(&self) -> TxDriverAmMod {
         let val = (self.0 >> 4usize) & 0x0f;
@@ -3205,6 +3205,37 @@ impl From<u8> for RxConf1Lp {
 }
 impl From<RxConf1Lp> for u8 {
     fn from(val: RxConf1Lp) -> u8 {
+        val.0
+    }
+}
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+pub struct TxDriverDRes(pub u8);
+impl TxDriverDRes {
+    pub const _1_00: Self = Self(0);
+    pub const _1_19: Self = Self(0x01);
+    pub const _1_40: Self = Self(0x02);
+    pub const _1_61: Self = Self(0x03);
+    pub const _1_79: Self = Self(0x04);
+    pub const _2_02: Self = Self(0x05);
+    pub const _2_49: Self = Self(0x06);
+    pub const _2_94: Self = Self(0x07);
+    pub const _3_41: Self = Self(0x08);
+    pub const _4_06: Self = Self(0x09);
+    pub const _5_95: Self = Self(0x0a);
+    pub const _8_26: Self = Self(0x0b);
+    pub const _17_10: Self = Self(0x0c);
+    pub const _36_60: Self = Self(0x0d);
+    pub const _51_20: Self = Self(0x0e);
+    pub const _HIGH_Z: Self = Self(0x0f);
+}
+impl From<u8> for TxDriverDRes {
+    fn from(val: u8) -> Self {
+        Self(val)
+    }
+}
+impl From<TxDriverDRes> for u8 {
+    fn from(val: TxDriverDRes) -> u8 {
         val.0
     }
 }


### PR DESCRIPTION
To prepare for making RFO driver resistance of the ST25R39 configurable this change creates a TxDriverDRes struct to contain the possible values. This brings it in line with the way TxDriverAmMod works. (TxDriverAmMod is the other value in the same register.) 